### PR TITLE
Update zh-CN l11n

### DIFF
--- a/src/IronyModManager/Localization/zh.json
+++ b/src/IronyModManager/Localization/zh.json
@@ -1,8 +1,8 @@
 ﻿{
     "App": {
         "FontFamily": "Noto Sans SC", // Do not translate this, this is the font used by this locale
-        "Title": "Irony Mod Manager: v{AppVersion}",
-        "BackgroundOperationMessage": "请等待后台任务完成，应用程序会在完成后台任务后关闭...",
+        "Title": "Irony 模组管理器：v{AppVersion}",
+        "BackgroundOperationMessage": "请等待后台任务完成，应用程序会在完成后台任务后关闭……",
         "WaitBackgroundOperationMessage": "请等待后台任务完成",
         "Shortcuts": {
             "Name": "快捷菜单",
@@ -13,13 +13,13 @@
         }
     },
     "FatalError": {
-        "Message": "发生了未经处理的异常，程序即将关闭",
+        "Message": "发生了无法处理的异常，程序即将关闭",
         "Title": "错误",
         "Header": "严重错误"
     },
     "SavingError": {
         "Title": "保存失败",
-        "Message": "无法读写Mod文件，请将这个错误发送到Github Issue并附上错误日志"
+        "Message": "Irony 无法写入模组文件，请将这个错误发送至 GitHub Issue 并附上错误日志"
     },
     "Prompt": {
         "Yes": "是",
@@ -28,7 +28,7 @@
     "FileDialog": {
         "FileName": "文件名",
         "ShowHiddenFiles": "显示隐藏文件",
-        "Volume": "容量 {Size}",
+        "Volume": "卷 {Size}",
         "OK": "确定",
         "Cancel": "取消",
         "Name": "名称",
@@ -51,105 +51,105 @@
         "Name": "主题",
         "Light": "亮色",
         "Dark": "暗色",
-        "MaterialDark": "黑色",
-        "MaterialLightGreen": "亮绿",
-        "MaterialDeepPurple": "深紫",
+        "MaterialDark": "Material 暗色",
+        "MaterialLightGreen": "Material 亮绿",
+        "MaterialDeepPurple": "Material 深紫",
         "Restart_Title": "需要重启",
         "Restart_Header": "应用程序需要重启",
-        "Restart_Message": "应用程序需要重启来应用新的主题. 是否现在重启?"
+        "Restart_Message": "应用程序需要重启来应用新的主题。是否现在重启？"
     },
     "Games": {
         "Name": "游戏",
-        "Stellaris": "Stellaris",
-        "EuropaUniversalisIV": "Europa Universalis IV",
-        "HeartsofIronIV": "Hearts of Iron IV",
-        "ImperatorRome": "Imperator Rome",
-        "CrusaderKings3": "Crusader Kings III"
+        "Stellaris": "群星",
+        "EuropaUniversalisIV": "欧陆风云 IV",
+        "HeartsofIronIV": "钢铁雄心 IV",
+        "ImperatorRome": "帝皇：罗马",
+        "CrusaderKings3": "王国风云 III"
     },
     "Installed_Mods": {
-        "Name": "已安装Mods",
-        "Filter": "过滤Mods",
+        "Name": "已安装模组",
+        "Filter": "过滤模组",
         "Selected": "选择",
-        "Mod_Name": "Mod名称",
+        "Mod_Name": "模组名称",
         "Supported_Version": "支持的版本",
-        "LoadingMods": "正在加载Mod数据...",
-        "RefreshingModList": "正在刷新Mods列表...",
+        "LoadingMods": "正在加载模组数据……",
+        "RefreshingModList": "正在刷新模组列表……",
         "InvalidMods": {
-            "Title": "检测到无效Mod",
-            "Message": "下列Mod缺失:{NewLine}{Mods}.{NewLine}{NewLine}是否删除对应的说明文件?"
+            "Title": "检测到无效模组",
+            "Message": "下列模组丢失：{NewLine}{Mods}.{NewLine}{NewLine}是否删除对应的描述文件？"
         }
     },
     "Collection_Mods": {
-        "Name": "Mod整合包",
+        "Name": "模组合集",
         "Remove": "-",
         "Create": "+",
         "OK": "确定",
         "Cancel": "取消",
-        "Watermark": "输入整合包名称",
-        "Delete_Title": "删除此整合包?",
+        "Watermark": "输入新合集名称",
+        "Delete_Title": "删除此合集？",
         "Delete_Header": "确认删除操作",
-        "Delete_Message": "即将删除 {CollectionName}，请确认",
+        "Delete_Message": "是否确认删除合集 {CollectionName}？",
         "Export": "导出",
         "Import": "导入",
-        "Export_Dialog_Title": "导出整合包",
-        "Import_Dialog_Title": "导入整合包",
-        "Overlay_Exporting_Message": "正在导出整合包...",
-        "Overlay_Importing_Message": "正在导入整合包...",
-        "Filter": "搜索Mods",
-        "Selected": "选择",
-        "Mod_Name": "Mod名称",
+        "Export_Dialog_Title": "导出合集",
+        "Import_Dialog_Title": "导入合集",
+        "Overlay_Exporting_Message": "正在导出合集……",
+        "Overlay_Importing_Message": "正在导入合集……",
+        "Filter": "搜索模组",
+        "Selected": "已选中",
+        "Mod_Name": "模组名称",
         "Order": "顺序",
         "Rename": "重命名",
-        "Duplicate": "创建整合包副本",
-        "Overlay_Rename_Message": "正在重命名...",
-        "Overlay_Duplicate_Message": "正在创建整合包副本...",
-        "ExportToClipboard": "复制整合包到剪贴板",
+        "Duplicate": "创建副本",
+        "Overlay_Rename_Message": "正在重命名……",
+        "Overlay_Duplicate_Message": "正在创建合集副本……",
+        "ExportToClipboard": "导出合集至剪贴板",
         "DeleteMerge": {
-            "DeleteTitle": "删除合并的Mod？",
-            "DeleteHeader": "确认合并国防部删除",
-            "DeleteMessage": "已检测到合并mod的存在，是否也要删除它？"
+            "DeleteTitle": "删除合并模组？",
+            "DeleteHeader": "确认合并模组删除",
+            "DeleteMessage": "检测到合并模组的存在，是否同时删除它？"
         },
         "ImportFromClipboard": {
-            "Title": "从剪贴板导入整合包",
-            "PromptTitle": "覆盖整合包",
-            "PromptMessage": "此操作将会覆盖你Mod加载顺序与选择的Mod，请确认"
+            "Title": "从剪贴板导入合集",
+            "PromptTitle": "覆盖合集？",
+            "PromptMessage": "此操作将会覆盖你的模组加载顺序与选中的模组，是否继续？"
         },
         "FileHash": {
-            "Export": "导出收集哈希",
-            "Import": "验证收集哈希",
+            "Export": "导出合集文件指纹",
+            "Import": "验证合集文件指纹",
             "DialogTitleExport": "选择导出报告的位置",
-            "DialogTitleImport": "选择要导入的JSON报告",
-            "ExportOverlay": "汇出时请稍候...",
-            "ImportOverlay": "请等待验证...",
+            "DialogTitleImport": "选择要导入的 JSON 报告",
+            "ExportOverlay": "正在导出……",
+            "ImportOverlay": "正在验证……",
             "Progress": "{Progress}",
             "Close": "关闭"
         },
         "JumpOnDragAndDrop": {
-            "Title": "自动选择: {State}",
+            "Title": "自动选择：{State}",
             "On": "开启",
             "Off": "关闭"
         },
         "ImportPrompt": {
-            "Title": "整合包已存在",
-            "Message": "整合包已存在, 是否覆盖?"
+            "Title": "合集已存在",
+            "Message": "合集已存在并将被覆盖, 是否继续？"
         },
         "ImportOther": {
-            "Title": "...",
-            "Paradoxos": "从Paradoxos导入",
+            "Title": "…",
+            "Paradoxos": "从 Paradoxos 导入",
             "Paradox": "从游戏导入",
-            "ParadoxLauncher": "从Paradox 启动器导入",
+            "ParadoxLauncher": "从 Paradox 启动器导入",
             "Close": "关闭"
         },
         "ExportOther": {
-            "Title": "...",
-            "OrderOnly": "仅导出Mod加载顺序",
+            "Title": "…",
+            "OrderOnly": "仅导出模组加载顺序",
             "Close": "关闭"
         },
         "MergeCollection": {
             "Name": "合并",
             "MergedCollectionPrefix": "(Merged)", // It's used in path generation so should not be translated (depending on the type of language)
             "MergeCompressModPrefix": "(Merged {Name})", // It's used in path generation so should not be translated (depending on the type of language)
-            "Overlay_Progress": "进度 {Count}/{TotalCount}: {PercentDone}",
+            "Overlay_Progress": "步骤 {Count}/{TotalCount}：{PercentDone}",
             "Options": {
                 "Title": "选择模式",
                 "Basic": "基础",
@@ -158,74 +158,74 @@
                 "Close": "关闭"
             },
             "Advanced": {
-                "Overlay_Loading_Definitions": "正在加载Mod数据...",
-                "Overlay_Analyzing_Definitions": "正在分析Mod数据...",
-                "Overlay_Merging_Collection": "正在合并整合包..."
+                "Overlay_Loading_Definitions": "正在加载模组数据……",
+                "Overlay_Analyzing_Definitions": "正在分析模组数据……",
+                "Overlay_Merging_Collection": "正在合并合集……"
             },
             "Basic": {
-                "Overlay_Gathering_Mod_Info": "正在收集Mod信息...",
-                "Overlay_Writting_Files": "正在写入文件..."
+                "Overlay_Gathering_Mod_Info": "正在收集模组信息……",
+                "Overlay_Writting_Files": "正在合并合集……"
             },
             "Compress": {
-                "Overlay_Gathering_Mod_Info": "正在收集Mod信息...",
-                "Overlay_Compressing_Files": "正在写入文件..."
+                "Overlay_Gathering_Mod_Info": "正在收集模组信息……",
+                "Overlay_Compressing_Files": "正在合并合集……"
             },
             "OverwritePrompt": {
-                "Title": "覆盖现有整合包?",
-                "Message": "同名的整合包已存在，是否覆盖?"
+                "Title": "覆盖现有合集？",
+                "Message": "同名的合并模组已存在，是否覆盖？"
             }
         }
     },
     "Mod_Actions": {
-        "Apply": "加载此整合包",
-        "Overlay_Apply_Message": "正在加载整合包...",
-        "Conflict": "冲突处理",
-        "Overlay_Conflict_Solver_Loading_Definitions": "正在加载Mod数据...",
-        "Overlay_Conflict_Solver_Analyzing_Conflicts": "正在分析Mod冲突...",
-        "Overlay_Conflict_Solver_Analyzing_Resolved_Conflicts": "正在分析已处理的冲突...",
-        "Overlay_Conflict_Solver_Progress": "进度 {Count}/{TotalCount}: {PercentDone}",
+        "Apply": "加载合集",
+        "Overlay_Apply_Message": "正在加载合集……",
+        "Conflict": "冲突处理器",
+        "Overlay_Conflict_Solver_Loading_Definitions": "正在加载模组数据……",
+        "Overlay_Conflict_Solver_Analyzing_Conflicts": "正在分析模组冲突……",
+        "Overlay_Conflict_Solver_Analyzing_Resolved_Conflicts": "正在分析已处理的冲突……",
+        "Overlay_Conflict_Solver_Progress": "步骤 {Count}/{TotalCount}: {PercentDone}",
         "LaunchGame": {
             "Launch": "启动游戏",
             "Resume": "继续游戏",
-            "Overlay": "正在启动游戏，请稍候...",
+            "Overlay": "正在启动游戏……",
             "LaunchError": {
                 "Title": "无法启动游戏",
-                "Message": "启动失败."
+                "Message": "启动失败。"
             },
             "NotSet": {
                 "Title": "找不到游戏",
-                "Message": "请在-选项-里面设置游戏的路径"
+                "Message": "游戏自动检测失败，请在“选项”窗口中手动设置游戏可执行文件的路径"
             }
         }
     },
     "Conflict_Solver": {
         "Back": "返回",
-        "ConflictedObjects": "冲突",
+        "ConflictedObjects": "冲突的对象",
         "LeftSide": "左侧",
         "RightSide": "右侧",
         "BinaryFile": "二进制文件",
-        "ImageInfo": "宽度: {Width} 高度: {Height}",
+        "ImageInfo": "宽度：{Width} 高度：{Height}",
         "TakeLeft": "选择左侧文件",
         "TakeRight": "选择右侧文件",
         "OK": "确定",
         "Cancel": "取消",
-        "Resolve": "标记冲突已处理",
+        "Resolve": "标记为已处理",
         "Ignore": "忽略冲突",
         "IgnoreRules": "忽略规则",
-        "OverlayResolve": "正在处理冲突...",
+        "OverlayResolve": "正在处理冲突……",
         "NextConflict": "下一个冲突",
         "PrevConflict": "上一个冲突",
-        "ConflictCount": "冲突数: {Count}",
+        "ConflictCount": "冲突数：{Count}",
         "PriorityReason": {
-            "FIOS": "(FIOS)",
-            "LIOS": "(LIOS)",
-            "Order": "(Load Order)",
-            "Override": "(Override)"
+            "FIOS": "（先序优先）",
+            "LIOS": "（后序优先）",
+            "Order": "（加载顺序）",
+            "Override": "（覆盖）"
         },
         "InvalidConflicts": {
             "Name": "无效代码",
-            "Error": "错误位置：行：{Line} 列：{Column} 文件: {File}.{NewLine}请将此错误汇报到此Mod的作者: {ModName}.{NewLine}{NewLine} 错误信息：{NewLine}{NewLine}{Message}",
-            "ErrorNoLine": "错误文件: {File}.{NewLine}请将此错误汇报到此Mod的作者: {ModName}.{NewLine}{NewLine}错误信息：{NewLine}{NewLine}{Message}",
+            "Error": "发现错误于：文件：{File}，{Line} 行 {Column}列{NewLine} 请将此错误汇报至此模组的作者: {ModName}。{NewLine}{NewLine}错误信息：{NewLine}{NewLine}{Message}",
+            "ErrorNoLine": "发现错误于：文件: {File}{NewLine}请将此错误汇报至此模组的作者：{ModName}。{NewLine}{NewLine}错误信息：{NewLine}{NewLine}{Message}",
             "ContextMenu": {
                 "OpenFile": "打开文件",
                 "OpenDirectory": "打开目录",
@@ -244,7 +244,7 @@
             "MoveUp": "上移",
             "MoveDown": "下移",
             "Edit": "编辑",
-            "CopyText": "复制文本",
+            "CopyText": "复制全部文本",
             "Delete": "删除",
             "Undo": "撤销",
             "Redo": "重做"
@@ -253,7 +253,7 @@
             "Copy": "复制",
             "Cut": "剪切",
             "Delete": "删除",
-            "Paste": "黏贴",
+            "Paste": "粘贴",
             "Undo": "撤销",
             "Redo": "重做",
             "SelectAll": "全选"
@@ -265,22 +265,22 @@
             "Close": "关闭"
         },
         "ModFilter": {
-            "Title": "Mod过滤",
+            "Title": "模组过滤",
             "Close": "关闭"
         },
         "ResetConflicts": {
-            "Title": "重新标记冲突",
+            "Title": "重置冲突标记",
             "Resolved": "已处理",
-            "Ignored": "忽略",
+            "Ignored": "已忽略",
             "Custom": "自定义",
             "Close": "关闭",
-            "Reset": "标记冲突"
+            "Reset": "重置"
         },
         "DBSearch": {
-            "Title": "搜索数据库",
-            "Watermark": "输入搜索式",
+            "Title": "数据库搜索",
+            "Watermark": "输入搜索关键词",
             "Close": "关闭",
-            "Clear": "X"
+            "Clear": "×"
         },
         "CustomPatch": {
             "Title": "自定义补丁",
@@ -293,139 +293,139 @@
     "ConflictIgnore": {
         "Save": "保存",
         "Cancel": "取消",
-        "Watermark": "使用 # 标记注释，每行一条规则"
+        "Watermark": "用 # 表示注释，每行一条规则"
     },
     "Options": {
         "Name": "选项",
         "Close": "关闭",
         "Game": {
             "Title": "游戏选项",
-            "NavigateTo": "...",
-            "Reset": "X",
+            "NavigateTo": "…",
+            "Reset": "×",
             "GameExecutable": "游戏可执行文件",
-            "UserDirectory": "游戏存档目录",
-            "GameArgs": "启动参数",
-            "RefreshMods": "启动前刷新Mod Descriptor",
+            "UserDirectory": "游戏数据目录",
+            "GameArgs": "游戏启动参数",
+            "RefreshMods": "启动前刷新模组描述文件",
             "CloseAfterLaunch": "启动游戏后关闭",
-            "AutoConfigure": "设置所有..."
+            "AutoConfigure": "设置全部……"
         },
         "Updates": {
             "Title": "更新选项",
             "AutoUpdates": "启动时检查更新",
-            "CheckPrerelease": "更新到预览版",
+            "CheckPrerelease": "检查预发布版更新",
             "CheckForUpdates": "检查更新",
             "Install": "安装更新",
             "Version": "版本",
             "Overlay": {
-                "UpdateDownloading": "正在下载更新...",
+                "UpdateDownloading": "正在下载更新……",
                 "UpdateDownloadProgress": "{Progress}",
-                "UpdateInstalling": "正在解压文件，准备安装..."
+                "UpdateInstalling": "正在解压更新文件，准备启动安装程序……"
             },
             "Errors": {
                 "DownloadErrorTitle": "更新失败",
-                "DownloadErrorMessage": "下载更新失败，查看错误日志以获取详情."
+                "DownloadErrorMessage": "下载更新失败，查看错误日志以获取详情。"
             },
             "AutoUpdatePrompts": {
                 "Title": "自动检查更新",
-                "Message": "Irony 需要你授权在启动时进行更新检查. 是否允许 Irony 在有更新时提醒你?"
+                "Message": "Irony 需要你授权在启动时进行更新检查。是否允许 Irony 在有更新时提醒你？"
             },
             "UpdateNotification": {
-                "Title": "有新版本",
-                "Message": "在-选项-查看更新详情，或者点击本消息"
+                "Title": "检测到更新",
+                "Message": "在“选项”窗口查看更新详情，或点击此消息"
             }
         },
         "Dialog": {
             "ExeTitle": "选择游戏可执行文件",
-            "GameRootTitle": "选择游戏目录",
-            "UserDirTitle": "选择存档目录"
+            "GameRootTitle": "选择游戏根目录",
+            "UserDirTitle": "选择游戏数据目录"
         }
     },
     "Notifications": {
         "CollectionCreated": {
-            "Title": "已创建整合包",
-            "Message": "{CollectionName} 已创建"
+            "Title": "已创建合集",
+            "Message": "{CollectionName} 已创建。"
         },
         "CollectionDeleted": {
-            "Title": "已删除整合包",
-            "Message": "{CollectionName} 已删除"
+            "Title": "已删除合集",
+            "Message": "{CollectionName} 已删除。"
         },
         "CollectionAndModDeleted": {
-            "Title": "收集和合并的模组已删除",
-            "Message": "{CollectionName} 和合并的国防部已被删除"
+            "Title": "合集与合并模组已删除",
+            "Message": "{CollectionName} 与合并模组已删除。"
         },
         "CollectionExists": {
-            "Title": "整合包已存在",
-            "Message": "{CollectionName} 已存在"
+            "Title": "合集已存在",
+            "Message": "{CollectionName} 已存在。"
         },
         "CollectionExported": {
-            "Title": "整合包已导出",
-            "Message": "{CollectionName} 已导出"
+            "Title": "合集已导出",
+            "Message": "{CollectionName} 已导出。"
         },
         "CollectionImported": {
-            "Title": "已导入整合包",
-            "Message": "{CollectionName} 已导入"
+            "Title": "已导入合集",
+            "Message": "{CollectionName} 已导入。"
         },
         "CollectionApplied": {
-            "Title": "整合包已加载",
-            "Message": "{CollectionName} 已加载"
+            "Title": "合集已加载",
+            "Message": "{CollectionName} 已加载。"
         },
         "CollectionNotApplied": {
             "Title": "没有加载",
-            "Message": "{CollectionName} 没有加载"
+            "Message": "{CollectionName} 未加载。"
         },
         "DescriptorsRefreshed": {
-            "Title": "Descriptors 已刷新",
-            "Message": "Descriptors 已刷新"
+            "Title": "描述文件已刷新",
+            "Message": "描述文件已刷新。"
         },
         "DescriptorsLocked": {
-            "Title": "Descriptors 已锁定",
-            "Message": "Descriptors 已锁定"
+            "Title": "描述文件已被锁定",
+            "Message": "描述文件已被锁定。"
         },
         "DescriptorsUnlocked": {
-            "Title": "Descriptors 已解锁",
-            "Message": "Descriptors 已解锁"
+            "Title": "描述文件已被解锁",
+            "Message": "描述文件已被解锁。"
         },
         "NewDescriptorsChecked": {
-            "Title": "检查新Mods完成",
-            "Message": "检查新Mods完成"
+            "Title": "检查新模组完成",
+            "Message": "检查新模组完成。"
         },
         "CollectionRenamed": {
-            "Title": "已重命名整合包",
-            "Message": "已重命名整合包"
+            "Title": "已重命名合集",
+            "Message": "已重命名合集。"
         },
         "CollectionDuplicated": {
-            "Title": "已创建整合包副本",
-            "Message": "已创建整合包副本"
+            "Title": "已创建合集副本",
+            "Message": "已创建合集副本。"
         },
         "CollectionMerged": {
-            "Title": "整合包已合并",
-            "Message": "整合包已合并"
+            "Title": "合集已合并",
+            "Message": "合集已合并。"
         },
         "ConflictSolverUpdate": {
-            "Title": "冲突处理需要更新",
-            "Message": "一个或多个Mod已更新，冲突处理刷新数据"
+            "Title": "冲突处理器更新",
+            "Message": "一个或多个模组已更新，冲突处理器需要刷新数据。"
         },
         "NoUpdatesAvailable": {
             "Title": "没有更新",
-            "Message": "没有可用更新"
+            "Message": "没有可用更新。"
         },
         "ReportExported": {
             "Title": "报告已导出",
-            "Message": "报告已导出."
+            "Message": "报告已导出。"
         },
         "ReportValid": {
-            "Title": "文件哈希匹配",
-            "Message": "所有文件散列似乎都匹配."
+            "Title": "文件指纹匹配",
+            "Message": "所有文件指纹似乎均匹配。"
         }
     },
     "Mod_App_Actions": {
-        "OpenInSteam": "在Steam中打开",
-        "Open": "打开Mod链接",
-        "Copy": "复制Mod链接",
-        "OpenInAssociatedApp": "打开Mod目录/文件"
+        "OpenInSteam": "在 Steam 中打开",
+        "Open": "打开模组链接",
+        "Copy": "复制模组链接",
+        "OpenInAssociatedApp": "打开模组目录或文件"
     },
     "Descriptor_Actions": {
-        "CheckNew": "检查新Mods",
+        "CheckNew": "检查新模组",
         "Delete": "删除并重载",
         "Delete_All": "删除并重载所有",
         "Lock": "锁定",
@@ -434,15 +434,15 @@
         "Unlock_All": "解锁所有"
     },
     "Achievements": {
-        "AchievementCompatible": "Mod兼容成就",
-        "NotAchievementCompatible": "Mod不兼容成就"
+        "AchievementCompatible": "模组兼容成就",
+        "NotAchievementCompatible": "模组不兼容成就"
     },
     "Sorting": {
         "Sort_A_Z": "↑",
         "Sort_Z_A": "↓"
     },
     "Filter": {
-        "Clear": "X",
+        "Clear": "×",
         "UpArrow": "▲",
         "DownArrow": "▼"
     }


### PR DESCRIPTION
- Add translation for new features
- Replace all English punctuation mark with Chinese ones
- Translate some untranslated parts, e.g. game name
- Fix wrong translation to fit the context
- Translate app name (terminology `Irony` is left untouched)
- Change some translation for consistency of tone and terminology usage
- Fix space usage for consistency