### PR TITLE
If there are 4+ definitions including the virtual definition, skip the stellaris definition if its there when the conflict is being selected as the default selected definition for the left side

### DIFF
--- a/src/IronyModManager/ViewModels/Controls/ModCompareSelectorControlViewModel.cs
+++ b/src/IronyModManager/ViewModels/Controls/ModCompareSelectorControlViewModel.cs
@@ -247,7 +247,8 @@ namespace IronyModManager.ViewModels.Controls
                         await Task.Delay(50, token);
                         if (!token.IsCancellationRequested)
                         {
-                            LeftSelectedDefinition = virtualDefinitions.FirstOrDefault(p => p != newDefinition && p != priorityDefinition.Definition);
+                            int virtualDefCount = virtualDefinitions.Count();
+                            LeftSelectedDefinition = virtualDefinitions.FirstOrDefault(p => p != newDefinition && p != priorityDefinition.Definition && !(virtualDefCount >= 4 && p.OriginalModName == "Stellaris"));
                             RightSelectedDefinition = newDefinition;
                         }
                     }

--- a/src/IronyModManager/ViewModels/Controls/ModCompareSelectorControlViewModel.cs
+++ b/src/IronyModManager/ViewModels/Controls/ModCompareSelectorControlViewModel.cs
@@ -248,7 +248,7 @@ namespace IronyModManager.ViewModels.Controls
                         if (!token.IsCancellationRequested)
                         {
                             int virtualDefCount = virtualDefinitions.Count();
-                            LeftSelectedDefinition = virtualDefinitions.FirstOrDefault(p => p != newDefinition && p != priorityDefinition.Definition && !(virtualDefCount >= 4 && p.OriginalModName == "Stellaris"));
+                            LeftSelectedDefinition = virtualDefinitions.FirstOrDefault(p => p != newDefinition && p != priorityDefinition.Definition && !(virtualDefCount >= 4 && p.IsFromGame));
                             RightSelectedDefinition = newDefinition;
                         }
                     }

--- a/src/IronyModManager/ViewModels/Controls/ModCompareSelectorControlViewModel.cs
+++ b/src/IronyModManager/ViewModels/Controls/ModCompareSelectorControlViewModel.cs
@@ -249,6 +249,10 @@ namespace IronyModManager.ViewModels.Controls
                         {
                             int virtualDefCount = virtualDefinitions.Count();
                             LeftSelectedDefinition = virtualDefinitions.FirstOrDefault(p => p != newDefinition && p != priorityDefinition.Definition && !(virtualDefCount >= 4 && p.IsFromGame));
+                            if (LeftSelectedDefinition == null)
+                            {
+                                LeftSelectedDefinition = virtualDefinitions.FirstOrDefault(p => p != newDefinition && p != priorityDefinition.Definition);
+                            }
                             RightSelectedDefinition = newDefinition;
                         }
                     }


### PR DESCRIPTION
If there are 4+ definitions including the virtual definition, skip the stellaris definition if its there when the conflict is being selected as the default selected definition for the left side

example:
https://i.imgur.com/IHLVoUF.png