### PR TITLE
bugfix/display-mod-names-with-escaped-quotations

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,7 @@ Check the [Wiki](https://github.com/bcssov/IronyModManager/wiki)
 
 # Building Irony Mod Manager
 All instructions are for Windows.
-1. Install Visual Studio 2019
+1. Install Visual Studio 2022 (required for .NET6)
 1. Clone the repo to your local machine
 1. Open the LocalizationResourceGenerator solution file located in \Tools\LocalizationResourceGenerator\src
     * Build the solution and copy the binaries to the Tools\LocalizationResourceGenerator folder

--- a/src/IronyModManager.Parser.Tests/ModParserTests.cs
+++ b/src/IronyModManager.Parser.Tests/ModParserTests.cs
@@ -99,5 +99,48 @@ namespace IronyModManager.Parser.Tests
             var result = parser.Parse(sb.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries));            
             result.FileName.Should().Be("path");            
         }
+
+        /// <summary>
+        /// Defines the test method Should_parse_mod_file.
+        /// </summary>
+        [Fact]
+        public void Should_parse_mod_file_with_escaped_quotations()
+        {
+            DISetup.SetupContainer();
+
+            var sb = new StringBuilder();
+            sb.AppendLine(@"name=""AI Species \""Limit\""""");
+            sb.AppendLine(@"path=""path""");
+            sb.AppendLine(@"user_dir=""dir""");
+            sb.AppendLine(@"replace_path=""replace""");
+            sb.AppendLine(@"tags={");
+            sb.AppendLine(@"	""Gameplay""");
+            sb.AppendLine(@"	""Fixes""");
+            sb.AppendLine(@"}");
+            sb.AppendLine(@"picture=""thumbnail.png""");
+            sb.AppendLine(@"supported_version=""2.5.*""");
+            sb.AppendLine(@"remote_file_id=""1830063425""");
+            sb.AppendLine(@"version = ""version""");
+            sb.AppendLine(@"dependencies = {");
+            sb.AppendLine(@"	""fake""");
+            sb.AppendLine(@"}");
+
+            var parser = new ModParser(new CodeParser(new Logger()));
+            var result = parser.Parse(sb.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries));
+            result.Dependencies.Count().Should().Be(1);
+            result.Dependencies.First().Should().Be("fake");
+            result.FileName.Should().Be("path");
+            result.Name.Should().Be("AI Species \"Limit\"");
+            result.Picture.Should().Be("thumbnail.png");
+            result.RemoteId.Should().Be(1830063425);
+            result.Tags.Count().Should().Be(2);
+            result.Tags.First().Should().Be("Gameplay");
+            result.Tags.Last().Should().Be("Fixes");
+            result.Version.Should().Be("2.5.*");
+            result.UserDir.Count().Should().Be(1);
+            result.UserDir.FirstOrDefault().Should().Be("dir");
+            result.ReplacePath.Count().Should().Be(1);
+            result.ReplacePath.FirstOrDefault().Should().Be("replace");
+        }
     }
 }

--- a/src/IronyModManager.Parser.Tests/ModParserTests.cs
+++ b/src/IronyModManager.Parser.Tests/ModParserTests.cs
@@ -3,8 +3,8 @@
 // Author           : Mario
 // Created          : 02-22-2020
 //
-// Last Modified By : Mario
-// Last Modified On : 08-11-2020
+// Last Modified By : Nick Butcher
+// Last Modified On : 12-12-2021
 // ***********************************************************************
 // <copyright file="ModParserTests.cs" company="Mario">
 //     Mario

--- a/src/IronyModManager.Parser/BaseGenericObjectParser.cs
+++ b/src/IronyModManager.Parser/BaseGenericObjectParser.cs
@@ -3,8 +3,8 @@
 // Author           : Mario
 // Created          : 02-13-2021
 //
-// Last Modified By : Mario
-// Last Modified On : 02-26-2021
+// Last Modified By : Nick Butcher
+// Last Modified On : 12-12-2021
 // ***********************************************************************
 // <copyright file="BaseGenericObjectParser.cs" company="Mario">
 //     Mario

--- a/src/IronyModManager.Parser/BaseGenericObjectParser.cs
+++ b/src/IronyModManager.Parser/BaseGenericObjectParser.cs
@@ -64,7 +64,7 @@ namespace IronyModManager.Parser
         /// <returns>T.</returns>
         protected static T Convert<T>(string value)
         {
-            value = value.Trim().Trim('"');
+            value = value.Trim().Trim('"').Replace("\\\"", "\"");
             var converter = GetConverter<T>();
             return converter.IsValid(value) ? (T)converter.ConvertFromString(value) : default;
         }


### PR DESCRIPTION
Irony fails to parse the names of two of my mods which have escaped quotation marks.  I added code to replace the raw escape sequence with a single quotation mark (after trimming the string-delimiting quotation marks) and also a unit test to exercise the code.  The `\"` escape sequence is supported by both Steam and the Paradox Launcher.

l also updated to readme to note that Visual Studio 2022 is required because the application is a .NET6 application.

Example mods:

* ["Agrarian" Idyll for Lithoids](https://steamcommunity.com/sharedfiles/filedetails/?id=2510669821)
* ["Terraform" to Tomb World](https://steamcommunity.com/sharedfiles/filedetails/?id=2625663437)