### PR TITLE
Minor Chinese localization update: Added translation for the new game name - Europa Universalis V

### DIFF
--- a/src/IronyModManager/Localization/zh.json
+++ b/src/IronyModManager/Localization/zh.json
@@ -93,7 +93,7 @@
     "Name": "游戏",
     "Stellaris": "群星",
     "EuropaUniversalisIV": "欧陆风云 Ⅳ",
-    "EuropaUniversalisV": "Europa Universalis V",
+    "EuropaUniversalisV": "欧陆风云 Ⅴ",
     "HeartsofIronIV": "钢铁雄心 Ⅳ",
     "ImperatorRome": "帝皇：罗马",
     "CrusaderKings3": "十字军之王 Ⅲ",


### PR DESCRIPTION
I noticed that this manager has added support for Europa Universalis V, but the game name in the localization file had not been translated yet, so I translated it into the corresponding Chinese name. Thank you for your work.